### PR TITLE
feat: #5 - Add support ENDPOINT Store and fixeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to `alexssander-cusin/panic-control-laravel` will be documented in this file.
 
 ## v1.1.1 - 2023-XX-XX
+- [FEATURE] Add support a database connections [#7](https://github.com/alexssander-cusin/panic-control-laravel/issues/7)
 - [FIXED] Importing PanicControl\Stores\FileStore on provider
 
 ## v1.1.0 - 2023-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 All notable changes to `alexssander-cusin/panic-control-laravel` will be documented in this file.
 
-## v1.2.0 - 2023-XX-XX
-- [FEATURE] Add support ENDPOINT Store [#5](https://github.com/alexssander-cusin/panic-control-laravel/issues/5)
-- [FEATURE] Add support a database connections [#7](https://github.com/alexssander-cusin/panic-control-laravel/issues/7)
+## v1.1.1 - 2023-XX-XX
+- [FIXED] Importing PanicControl\Stores\FileStore on provider
 
 ## v1.1.0 - 2023-07-04
 - Support File Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 All notable changes to `alexssander-cusin/panic-control-laravel` will be documented in this file.
 
-## v1.1.1 - 2023-07-06
+## v1.2.0 - 2023-XX-XX
+- [FEATURE] Add support ENDPOINT Store [#5](https://github.com/alexssander-cusin/panic-control-laravel/issues/5)
 - [FEATURE] Add support a database connections [#7](https://github.com/alexssander-cusin/panic-control-laravel/issues/7)
 
 ## v1.1.0 - 2023-07-04
 - Support File Store
+
 ## v1.0.0 - 2023-05-26
 
 - Create Panic Control with [Facade]/[Command]/[Helper];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `alexssander-cusin/panic-control-laravel` will be documented in this file.
 
+## v1.2.0 - 2023-XX-XX
+- [FEATURE] Add support ENDPOINT Store [#5](https://github.com/alexssander-cusin/panic-control-laravel/issues/5)
+
 ## v1.1.1 - 2023-XX-XX
 - [FEATURE] Add support a database connections [#7](https://github.com/alexssander-cusin/panic-control-laravel/issues/7)
 - [FIXED] Importing PanicControl\Stores\FileStore on provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to `alexssander-cusin/panic-control-laravel` will be documen
 
 ## v1.2.0 - 2023-XX-XX
 - [FEATURE] Add support ENDPOINT Store [#5](https://github.com/alexssander-cusin/panic-control-laravel/issues/5)
-
-## v1.1.1 - 2023-XX-XX
 - [FEATURE] Add support a database connections [#7](https://github.com/alexssander-cusin/panic-control-laravel/issues/7)
 - [FIXED] Importing PanicControl\Stores\FileStore on provider
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can install the package via composer:
 composer require alexssander-cusin/panic-control-laravel
 ```
 
-You can publish and run the migrations with:
+You can publish and run the migrations with (only for database store):
 
 ```bash
 php artisan vendor:publish --tag="panic-control-laravel-migrations"
@@ -75,6 +75,14 @@ return [
             */
             
             'path' => 'panic-control.json',
+        ],
+        'endpoint' => [
+            /**
+             *--------------------------------------------------------------------------
+             * Defines the URL of the endpoint
+             *--------------------------------------------------------------------------
+             */
+            'url' => 'https://localhost/panic-control.json',
         ],
     ],
     'cache' => [
@@ -139,7 +147,7 @@ return [
 
 ### Facade
 
-Create a Panic Control:
+Create a Panic Control [^1]
 
 ```php
 use PanicControl\Facades\PanicControl;
@@ -151,7 +159,7 @@ PanicControl::create([
 ]);
 ```
 
-Update a Panic Control:
+Update a Panic Control [^1]
 
 ```php
 use PanicControl\Facades\PanicControl;
@@ -162,7 +170,7 @@ PanicControl::update($panic, [
 ]);
 ```
 
-Get all Panic Control:
+Get all Panic Control
 
 ```php
 use PanicControl\Facades\PanicControl;
@@ -170,7 +178,7 @@ use PanicControl\Facades\PanicControl;
 PanicControl::all();
 ```
 
-Get a Panic Control:
+Get a Panic Control
 
 ```php
 use PanicControl\Facades\PanicControl;
@@ -206,13 +214,13 @@ Detail a Panic Control
 php artisan panic-control:show panic-control-name
 ```
 
-Activate a Panic Control
+Activate a Panic Control [^1]
 
 ```bash
 php artisan panic-control:active panic-control-name
 ```
 
-Deactivate a Panic Control
+Deactivate a Panic Control [^1]
 
 ```bash
 php artisan panic-control:desactive panic-control-name
@@ -372,3 +380,5 @@ Please review [our security policy](../../security/policy) on how to report secu
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+
+[^1]: Not supported for *endpoint store*.

--- a/README.md
+++ b/README.md
@@ -76,14 +76,6 @@ return [
             
             'path' => 'panic-control.json',
         ],
-        'endpoint' => [
-            /**
-             *--------------------------------------------------------------------------
-             * Defines the URL of the endpoint
-             *--------------------------------------------------------------------------
-             */
-            'url' => 'https://localhost/panic-control.json',
-        ],
     ],
     'cache' => [
         /** 
@@ -147,7 +139,7 @@ return [
 
 ### Facade
 
-Create a Panic Control [^1]
+Create a Panic Control
 
 ```php
 use PanicControl\Facades\PanicControl;
@@ -159,7 +151,7 @@ PanicControl::create([
 ]);
 ```
 
-Update a Panic Control [^1]
+Update a Panic Control
 
 ```php
 use PanicControl\Facades\PanicControl;
@@ -214,13 +206,13 @@ Detail a Panic Control
 php artisan panic-control:show panic-control-name
 ```
 
-Activate a Panic Control [^1]
+Activate a Panic Control
 
 ```bash
 php artisan panic-control:active panic-control-name
 ```
 
-Deactivate a Panic Control [^1]
+Deactivate a Panic Control
 
 ```bash
 php artisan panic-control:desactive panic-control-name
@@ -380,5 +372,3 @@ Please review [our security policy](../../security/policy) on how to report secu
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
-
-[^1]: Not supported for *endpoint store*.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ return [
             
             'path' => 'panic-control.json',
         ],
+        'endpoint' => [
+            /**
+             *--------------------------------------------------------------------------
+             * Defines the URL of the endpoint
+             *--------------------------------------------------------------------------
+             */
+            'url' => 'https://localhost/panic-control.json',
+        ],
     ],
     'cache' => [
         /** 
@@ -139,7 +147,7 @@ return [
 
 ### Facade
 
-Create a Panic Control
+Create a Panic Control [^1]
 
 ```php
 use PanicControl\Facades\PanicControl;
@@ -151,7 +159,7 @@ PanicControl::create([
 ]);
 ```
 
-Update a Panic Control
+Update a Panic Control [^1]
 
 ```php
 use PanicControl\Facades\PanicControl;
@@ -206,13 +214,13 @@ Detail a Panic Control
 php artisan panic-control:show panic-control-name
 ```
 
-Activate a Panic Control
+Activate a Panic Control [^1]
 
 ```bash
 php artisan panic-control:active panic-control-name
 ```
 
-Deactivate a Panic Control
+Deactivate a Panic Control [^1]
 
 ```bash
 php artisan panic-control:desactive panic-control-name
@@ -372,3 +380,5 @@ Please review [our security policy](../../security/policy) on how to report secu
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+
+[^1]: Not supported for *endpoint store*.

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,13 @@
     ],
     "require": {
         "php": "^8.1",
-        "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0"
+        "guzzlehttp/guzzle": "^7.7",
+        "illuminate/contracts": "^10.0",
+        "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
+        "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^7.9",
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^8.0",

--- a/config/panic-control.php
+++ b/config/panic-control.php
@@ -45,6 +45,14 @@ return [
              */
             'path' => 'panic-control.json',
         ],
+        'endpoint' => [
+            /**
+             *--------------------------------------------------------------------------
+             * Defines the URL of the endpoint
+             *--------------------------------------------------------------------------
+             */
+            'url' => 'https://localhost/panic-control.json',
+        ],
     ],
     'cache' => [
         /**

--- a/database/factories/PanicControlFactory.php
+++ b/database/factories/PanicControlFactory.php
@@ -16,6 +16,7 @@ class PanicControlFactory extends Factory
             'name' => Str::snake($this->faker->name),
             'description' => $this->faker->text,
             'status' => $this->faker->boolean(),
+            'rules' => [],
         ];
     }
 }

--- a/resources/stubs/PanicControlServiceProvider.php.stub
+++ b/resources/stubs/PanicControlServiceProvider.php.stub
@@ -7,6 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use PanicControl\Contracts\Store;
 use PanicControl\Stores\DatabaseStore;
 use PanicControl\Stores\FileStore;
+use PanicControl\Stores\EndpointStore;
 
 class PanicControlServiceProvider extends ServiceProvider implements DeferrableProvider
 {
@@ -23,6 +24,7 @@ class PanicControlServiceProvider extends ServiceProvider implements DeferrableP
         match (config('panic-control.default')) {
             'database' => $this->app->bind(Store::class, DatabaseStore::class),
             'file' => $this->app->bind(Store::class, FileStore::class),
+            'endpoint' => $this->app->bind(Store::class, EndpointStore::class),
             default => throw new \Exception('Invalid store provided'),
         };
     }

--- a/resources/stubs/PanicControlServiceProvider.php.stub
+++ b/resources/stubs/PanicControlServiceProvider.php.stub
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use PanicControl\Contracts\Store;
 use PanicControl\Stores\DatabaseStore;
+use PanicControl\Stores\FileStore;
 
 class PanicControlServiceProvider extends ServiceProvider implements DeferrableProvider
 {

--- a/src/Commands/PanicControlActiveCommand.php
+++ b/src/Commands/PanicControlActiveCommand.php
@@ -4,6 +4,7 @@ namespace PanicControl\Commands;
 
 use Illuminate\Console\Command;
 use PanicControl\Exceptions\PanicControlDoesNotExist;
+use PanicControl\Exceptions\PanicControlStoreNotSupport;
 use PanicControl\Facades\PanicControl;
 
 class PanicControlActiveCommand extends Command
@@ -24,7 +25,13 @@ class PanicControlActiveCommand extends Command
             return self::FAILURE;
         }
 
-        PanicControl::update($panicName, ['status' => true] + $panic);
+        try {
+            PanicControl::update($panicName, ['status' => true] + $panic);
+        } catch (PanicControlStoreNotSupport $th) {
+            $this->error("Panic Control: Store {$th->context()['store']} does not support update method.");
+
+            return self::FAILURE;
+        }
 
         $this->info("Panic Control: {$panicName} ativado com sucesso.");
 

--- a/src/Commands/PanicControlDesactiveCommand.php
+++ b/src/Commands/PanicControlDesactiveCommand.php
@@ -4,6 +4,7 @@ namespace PanicControl\Commands;
 
 use Illuminate\Console\Command;
 use PanicControl\Exceptions\PanicControlDoesNotExist;
+use PanicControl\Exceptions\PanicControlStoreNotSupport;
 use PanicControl\Facades\PanicControl;
 
 class PanicControlDesactiveCommand extends Command
@@ -24,7 +25,13 @@ class PanicControlDesactiveCommand extends Command
             return self::FAILURE;
         }
 
-        PanicControl::update($panicName, ['status' => false] + $panic);
+        try {
+            PanicControl::update($panicName, ['status' => false] + $panic);
+        } catch (PanicControlStoreNotSupport $th) {
+            $this->error("Panic Control: Store {$th->context()['store']} does not support update method.");
+
+            return self::FAILURE;
+        }
 
         $this->info("Panic Control: {$panicName} desativado com sucesso.");
 

--- a/src/Exceptions/PanicControlStoreNotSupport.php
+++ b/src/Exceptions/PanicControlStoreNotSupport.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PanicControl\Exceptions;
+
+use Exception;
+
+class PanicControlStoreNotSupport extends Exception
+{
+    public function __construct(protected string $store, protected string $method)
+    {
+        parent::__construct("Panic Control: Store {$this->store} does not support {$this->method} method.");
+    }
+
+    /**
+     * Get the exception's context information.
+     *
+     * @return array<string, mixed>
+     */
+    public function context(): array
+    {
+        return [
+            'store' => $this->store,
+            'method' => $this->method,
+        ];
+    }
+}

--- a/src/PanicControl.php
+++ b/src/PanicControl.php
@@ -23,6 +23,7 @@ class PanicControl
     protected function getCacheControl(string $panic = null): array
     {
         $cache = config('panic-control.cache');
+
         if (! self::$list) {
             $cacheStore = $cache['enabled'] ? $cache['store'] : 'array';
             self::$list = Cache::store($cacheStore)->remember($cache['key'], $cache['ttl'], function () {

--- a/src/Stores/DatabaseStore.php
+++ b/src/Stores/DatabaseStore.php
@@ -16,7 +16,6 @@ class DatabaseStore implements Store
 
     public function create(array $parameters): array
     {
-
         return PanicControl::create($parameters)->toArray();
     }
 

--- a/src/Stores/DatabaseStore.php
+++ b/src/Stores/DatabaseStore.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Log;
 use PanicControl\Contracts\Store;
 use PanicControl\Models\PanicControl;
 
-final class DatabaseStore implements Store
+class DatabaseStore implements Store
 {
     public function all(): array
     {

--- a/src/Stores/EndpointStore.php
+++ b/src/Stores/EndpointStore.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PanicControl\Stores;
+
+use Illuminate\Support\Facades\Http;
+use PanicControl\Contracts\Store;
+use PanicControl\Exceptions\PanicControlStoreNotSupport;
+
+class EndpointStore implements Store
+{
+    public function all(): array
+    {
+        return collect(Http::get(config('panic-control.stores.endpoint.url'))->json())
+            ->keyBy('name')
+            ->toArray();
+    }
+
+    public function create(array $parameters): array
+    {
+        throw new PanicControlStoreNotSupport('endpoint', 'create');
+    }
+
+    public function update(string|int $panicName, array $parameters): array
+    {
+        throw new PanicControlStoreNotSupport('endpoint', 'update');
+    }
+
+    public function count(): int
+    {
+        return count($this->all());
+    }
+}

--- a/src/Stores/FileStore.php
+++ b/src/Stores/FileStore.php
@@ -10,7 +10,7 @@ use PanicControl\Exceptions\PanicControlDoesNotExist;
 use PanicControl\Exceptions\PanicControlFileNotFound;
 use PanicControl\Facades\PanicControl;
 
-final class FileStore implements Store
+class FileStore implements Store
 {
     public function all(): array
     {

--- a/src/Validations/UniqueNameRule.php
+++ b/src/Validations/UniqueNameRule.php
@@ -21,10 +21,6 @@ class UniqueNameRule implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! in_array(config('panic-control.default'), ['database', 'file'])) {
-            $fail('The store configurada não é válida.');
-        }
-
         if ($this->ignore == $value) {
             return;
         }

--- a/tests/Datasets/Stores.php
+++ b/tests/Datasets/Stores.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Storage;
 use PanicControl\Contracts\Store;
 use PanicControl\Facades\PanicControl;
 use PanicControl\Stores\DatabaseStore;
+use PanicControl\Stores\EndpointStore;
 use PanicControl\Stores\FileStore;
 
 dataset('stores', [
@@ -22,6 +23,15 @@ dataset('stores', [
             Storage::disk(config('panic-control.stores.file.disk'))->delete(config('panic-control.stores.file.path'));
             Storage::disk(config('panic-control.stores.file.disk'))->put(config('panic-control.stores.file.path'), json_encode([]));
             PanicControl::clear();
+
+            return true;
+        },
+    ],
+    [
+        'store.endpoint', function () {
+            config()->set('panic-control.default', 'endpoint');
+
+            $this->app->bind(Store::class, EndpointStore::class);
 
             return true;
         },

--- a/tests/Datasets/Stores.php
+++ b/tests/Datasets/Stores.php
@@ -11,6 +11,7 @@ dataset('stores', [
     [
         'store.database', function () {
             config()->set('panic-control.default', 'database');
+
             $this->app->bind(Store::class, DatabaseStore::class);
 
             return true;
@@ -19,7 +20,9 @@ dataset('stores', [
     [
         'store.file', function () {
             config()->set('panic-control.default', 'file');
+
             $this->app->bind(Store::class, FileStore::class);
+
             Storage::disk(config('panic-control.stores.file.disk'))->delete(config('panic-control.stores.file.path'));
             Storage::disk(config('panic-control.stores.file.disk'))->put(config('panic-control.stores.file.path'), json_encode([]));
             PanicControl::clear();

--- a/tests/Feature/CommandTest.php
+++ b/tests/Feature/CommandTest.php
@@ -71,7 +71,7 @@ test('active a panic control on command', function (string $storeName, bool $sto
 
         expect(PanicControl::check($panic['name']))->toBeTrue();
     }
-})->with('stores')->only();
+})->with('stores');
 
 test('deactive a panic control on command', function (string $storeName, bool $store) {
     PanicControl::clear();

--- a/tests/Feature/CommandTest.php
+++ b/tests/Feature/CommandTest.php
@@ -6,42 +6,40 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
+use Mockery\MockInterface;
+use PanicControl\Contracts\Store;
 use PanicControl\Facades\PanicControl;
 use PanicControl\Models\PanicControl as PanicControlModel;
 
-beforeEach(function () {
-    //
-});
-
-test('show all panic control on command', function (string $storeName, bool $store) {
-
-    //Test empty panic control
+test('show all panic control on command but list is empty', function (string $storeName, bool $store) {
     match ($storeName) {
         'store.database' => PanicControlModel::truncate(),
         'store.file' => Storage::disk(config('panic-control.stores.file.disk'))->put(config('panic-control.stores.file.path'), json_encode([])),
+        'store.endpoint' => $this->partialMock(Store::class, function (MockInterface $mock) {
+            $mock->shouldReceive('all')
+                ->andReturn([]);
+        }),
     };
     PanicControl::clear();
     $this->artisan('panic-control:list')
         ->expectsOutputToContain('Nenhum Panic Control encontrado.')
         ->assertExitCode(Command::FAILURE);
+})->with('stores');
 
-    //List all panic control
-    $panics = PanicControlModel::factory()->count(3)->make()->toArray();
-    foreach ($panics as $panic) {
-        PanicControl::create($panic);
-    }
+test('show all panic control on command', function (string $storeName, bool $store) {
+    $panics = createPanic(count: 3);
+
     $this->artisan('panic-control:list')
         ->expectsOutputToContain($panics[0]['name'])
         ->expectsOutputToContain($panics[1]['name'])
         ->expectsOutputToContain($panics[2]['name'])
         ->assertExitCode(Command::SUCCESS);
-
 })->with('stores');
 
 test('show details a panic control on command', function (string $storeName, bool $store) {
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'name' => 'test',
-    ])->toArray());
+    ])[0];
 
     $this->artisan('panic-control:show', ['name' => 'test'])
         ->expectsOutputToContain($panic['name'])
@@ -67,17 +65,28 @@ test('active a panic control on command', function (string $storeName, bool $sto
 })->with('stores');
 
 test('deactive a panic control on command', function (string $storeName, bool $store) {
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    PanicControl::clear();
+
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
-    ])->toArray());
+    ])[0];
 
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
-    $this->artisan('panic-control:desactive', ['name' => $panic['name']])
-        ->expectsOutput("Panic Control: {$panic['name']} desativado com sucesso.")
-        ->assertExitCode(Command::SUCCESS);
+    if ($storeName == 'store.endpoint') {
+        $this->artisan('panic-control:desactive', ['name' => $panic['name']])
+            ->expectsOutput('Panic Control: Store endpoint does not support update method.')
+            ->assertExitCode(Command::FAILURE);
 
-    expect(PanicControl::check($panic['name']))->toBeFalse();
+        expect(PanicControl::check($panic['name']))->toBeTrue();
+    } else {
+        $this->artisan('panic-control:desactive', ['name' => $panic['name']])
+            ->expectsOutput("Panic Control: {$panic['name']} desativado com sucesso.")
+            ->assertExitCode(Command::SUCCESS);
+
+        expect(PanicControl::check($panic['name']))->toBeFalse();
+    }
+
 })->with('stores');
 
 test('create file when not exists and the store set file', function (string $storeName, bool $store) {

--- a/tests/Feature/CommandTest.php
+++ b/tests/Feature/CommandTest.php
@@ -51,22 +51,30 @@ test('show details a panic control on command', function (string $storeName, boo
 })->with('stores');
 
 test('active a panic control on command', function (string $storeName, bool $store) {
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    PanicControl::clear();
+    $panic = createPanic(count: 1, parameters: [
         'status' => false,
-    ])->toArray());
+    ])[0];
 
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
-    $this->artisan('panic-control:active', ['name' => $panic['name']])
-        ->expectsOutput("Panic Control: {$panic['name']} ativado com sucesso.")
-        ->assertExitCode(Command::SUCCESS);
+    if ($storeName == 'store.endpoint') {
+        $this->artisan('panic-control:active', ['name' => $panic['name']])
+            ->expectsOutput('Panic Control: Store endpoint does not support update method.')
+            ->assertExitCode(Command::FAILURE);
 
-    expect(PanicControl::check($panic['name']))->toBeTrue();
-})->with('stores');
+        expect(PanicControl::check($panic['name']))->toBeFalse();
+    } else {
+        $this->artisan('panic-control:active', ['name' => $panic['name']])
+            ->expectsOutput("Panic Control: {$panic['name']} ativado com sucesso.")
+            ->assertExitCode(Command::SUCCESS);
+
+        expect(PanicControl::check($panic['name']))->toBeTrue();
+    }
+})->with('stores')->only();
 
 test('deactive a panic control on command', function (string $storeName, bool $store) {
     PanicControl::clear();
-
     $panic = createPanic(count: 1, parameters: [
         'status' => true,
     ])[0];

--- a/tests/Feature/CommandTest.php
+++ b/tests/Feature/CommandTest.php
@@ -6,8 +6,6 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
-use Mockery\MockInterface;
-use PanicControl\Contracts\Store;
 use PanicControl\Facades\PanicControl;
 use PanicControl\Models\PanicControl as PanicControlModel;
 
@@ -15,12 +13,8 @@ test('show all panic control on command but list is empty', function (string $st
     match ($storeName) {
         'store.database' => PanicControlModel::truncate(),
         'store.file' => Storage::disk(config('panic-control.stores.file.disk'))->put(config('panic-control.stores.file.path'), json_encode([])),
-        'store.endpoint' => $this->partialMock(Store::class, function (MockInterface $mock) {
-            $mock->shouldReceive('all')
-                ->andReturn([]);
-        }),
+        'store.endpoint' => makeFakeEndpoint(response: [], status: 200),
     };
-    PanicControl::clear();
     $this->artisan('panic-control:list')
         ->expectsOutputToContain('Nenhum Panic Control encontrado.')
         ->assertExitCode(Command::FAILURE);
@@ -51,7 +45,6 @@ test('show details a panic control on command', function (string $storeName, boo
 })->with('stores');
 
 test('active a panic control on command', function (string $storeName, bool $store) {
-    PanicControl::clear();
     $panic = createPanic(count: 1, parameters: [
         'status' => false,
     ])[0];
@@ -74,7 +67,6 @@ test('active a panic control on command', function (string $storeName, bool $sto
 })->with('stores');
 
 test('deactive a panic control on command', function (string $storeName, bool $store) {
-    PanicControl::clear();
     $panic = createPanic(count: 1, parameters: [
         'status' => true,
     ])[0];

--- a/tests/Feature/HelperTest.php
+++ b/tests/Feature/HelperTest.php
@@ -1,16 +1,13 @@
 <?php
 
-use PanicControl\Facades\PanicControl;
-use PanicControl\Models\PanicControl as PanicControlModel;
-
 test('verify status on helper', function (string $storeName, bool $store) {
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
-    ])->toArray());
+    ])[0];
     $this->assertTrue(getPanicControlActive($panic['name']));
 
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => false,
-    ])->toArray());
+    ])[0];
     $this->assertFalse(getPanicControlActive($panic['name']));
 })->with('stores');

--- a/tests/Feature/RuleParametersTest.php
+++ b/tests/Feature/RuleParametersTest.php
@@ -3,17 +3,16 @@
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Lottery;
 use PanicControl\Facades\PanicControl;
-use PanicControl\Models\PanicControl as PanicControlModel;
 
 test('rule does not exist', function (string $storeName, bool $store) {
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'not-found' => [
                 'not-found-parameter',
             ],
         ],
-    ])->toArray());
+    ])[0];
 
     expect(fn () => PanicControl::check($panic['name']))->toThrow(\PanicControl\Exceptions\PanicControlRuleDoesNotExist::class);
 })->with('stores');
@@ -23,7 +22,7 @@ test('multi rules', function (string $storeName, bool $store) {
     \Illuminate\Support\Facades\Route::shouldReceive('currentRouteName')->andReturn('route-name-test');
 
     // Rules exists but Panic Control is disabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => false,
         'rules' => [
             'route-name' => [
@@ -33,11 +32,11 @@ test('multi rules', function (string $storeName, bool $store) {
                 'url-path-test',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Rules exists and Panic Control is enabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => [
@@ -47,11 +46,11 @@ test('multi rules', function (string $storeName, bool $store) {
                 'url-path-test',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Rules exists and Panic Control is enabled but one rule is false or null
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => [
@@ -60,11 +59,11 @@ test('multi rules', function (string $storeName, bool $store) {
             'url-path' => false,
             'sampling' => null,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Rules not list and Panic Control is enabled but one rule is false or null
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => [
@@ -73,11 +72,11 @@ test('multi rules', function (string $storeName, bool $store) {
             'url-path' => false,
             'sampling' => null,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Rules exists and Panic Control is enabled but one rule is not in the list
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => [
@@ -87,11 +86,11 @@ test('multi rules', function (string $storeName, bool $store) {
                 'url-path-error',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Rules exists and Panic Control is enabled but one rule is not in the list and the other is false
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => [
@@ -102,7 +101,7 @@ test('multi rules', function (string $storeName, bool $store) {
             ],
             'sampling' => false,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 })->with('stores');
 
@@ -110,54 +109,54 @@ test('rule route name', function (string $storeName, bool $store) {
     \Illuminate\Support\Facades\Route::shouldReceive('currentRouteName')->andReturn('route-name-test');
 
     // Route Name exists but Panic Control is disabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => false,
         'rules' => [
             'route-name' => [
                 'route-name-test',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Route Name exists and Panic Control is enabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => [
                 'route-name-test',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Route Name exists and Panic Control is enabled but the route name is not in the list
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => [
                 'route-name-error',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Panic Control is enabled but the route name set false
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => false,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Panic Control is enabled but the route name set null
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'route-name' => false,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 })->with('stores');
 
@@ -165,60 +164,60 @@ test('rule url path', function (string $storeName, bool $store) {
     $this->get('http://localhost/url-path-test');
 
     // Url Path exists but Panic Control is disabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => false,
         'rules' => [
             'url-path' => [
                 'url-path-test',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Url Path exists and Panic Control is enabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'url-path' => [
                 'url-path-test',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Url Path exists and Panic Control is enabled but the Url Path is not in the list
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'url-path' => [
                 'url-path-error',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Panic Control is enabled but the Url Path set false
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'url-path' => false,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Panic Control is enabled but the Url Path set null
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'url-path' => null,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 })->with('stores');
 
 test('rule user sampling', function (string $storeName, bool $store) {
     // Sampling exists but Panic Control is disabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => false,
         'rules' => [
             'sampling' => [
@@ -226,32 +225,32 @@ test('rule user sampling', function (string $storeName, bool $store) {
                 'out_of' => 10,
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Panic Control is enabled but the Sampling set false
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'sampling' => false,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Panic Control is enabled but the Sampling set null
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'sampling' => null,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     //Set all Sampling with true
     Lottery::alwaysWin();
 
     // Panic Control is enabled and Sampling return true
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'sampling' => [
@@ -259,7 +258,7 @@ test('rule user sampling', function (string $storeName, bool $store) {
                 'out_of' => 10,
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
     expect(Session::get("panic-control.{$panic['name']}.sampling"))->toBeTrue();
 
@@ -267,7 +266,7 @@ test('rule user sampling', function (string $storeName, bool $store) {
     Lottery::alwaysLose();
 
     // Panic Control is enabled but the Sampling return false
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'sampling' => [
@@ -275,12 +274,12 @@ test('rule user sampling', function (string $storeName, bool $store) {
                 'out_of' => 10,
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
     expect(Session::get("panic-control.{$panic['name']}.sampling"))->toBeFalse();
 
     // Panic Control is enabled but the Sampling return iquals chance all times
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'sampling' => [
@@ -288,7 +287,7 @@ test('rule user sampling', function (string $storeName, bool $store) {
                 'out_of' => 10,
             ],
         ],
-    ])->toArray());
+    ])[0];
     $chance = PanicControl::check($panic['name']);
     expect(Session::get("panic-control.{$panic['name']}.sampling"))->toBe($chance);
     for ($i = 0; $i < 10; $i++) {
@@ -298,7 +297,7 @@ test('rule user sampling', function (string $storeName, bool $store) {
 
 test('rule user', function (string $storeName, bool $store) {
     // Panic Control is enabled and the user is not logged in
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'user' => [
@@ -306,14 +305,14 @@ test('rule user', function (string $storeName, bool $store) {
                 1,
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     Auth::shouldReceive('check')->andReturn(true);
     Auth::shouldReceive('user')->andReturn((object) ['id' => 1, 'email' => 'user@test.com']);
 
     // User exists but Panic Control is disabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => false,
         'rules' => [
             'user' => [
@@ -321,68 +320,68 @@ test('rule user', function (string $storeName, bool $store) {
                 1,
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // User name exists and Panic Control is enabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'user' => [
                 'user@test.com',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // User ID exists and Panic Control is enabled
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'user' => [
                 1,
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Panic Control is enabled but the User Name is not in the list
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'user' => [
                 'error@test.com',
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Panic Control is enabled but the User ID is not in the list
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'user' => [
                 2,
             ],
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeFalse();
 
     // Panic Control is enabled but the User set false
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'user' => false,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 
     // Panic Control is enabled but the User set null
-    $panic = PanicControl::create(PanicControlModel::factory()->make([
+    $panic = createPanic(count: 1, parameters: [
         'status' => true,
         'rules' => [
             'user' => null,
         ],
-    ])->toArray());
+    ])[0];
     expect(PanicControl::check($panic['name']))->toBeTrue();
 })->with('stores');

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use PanicControl\Exceptions\PanicControlStoreNotSupport;
+use PanicControl\Facades\PanicControl;
+use PanicControl\Models\PanicControl as PanicControlModel;
+
+function createPanic($count = 1, $parameters = []): array
+{
+    $panics = PanicControlModel::factory()->count($count)->make($parameters)->toArray();
+
+    try {
+        foreach ($panics as $panic) {
+            PanicControl::create($panic);
+        }
+    } catch (PanicControlStoreNotSupport $th) {
+        if ($th->context()['store'] == 'endpoint') {
+            Http::fake([
+                '*' => Http::response($panics, 200),
+            ]);
+        } else {
+            throw $th;
+        }
+    } catch (\Throwable $th) {
+        throw $th;
+    }
+
+    return $panics;
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -15,9 +15,7 @@ function createPanic($count = 1, $parameters = []): array
         }
     } catch (PanicControlStoreNotSupport $th) {
         if ($th->context()['store'] == 'endpoint') {
-            Http::fake([
-                '*' => Http::response($panics, 200),
-            ]);
+            makeFakeEndpoint($panics, 200);
         } else {
             throw $th;
         }
@@ -26,4 +24,18 @@ function createPanic($count = 1, $parameters = []): array
     }
 
     return $panics;
+}
+
+function makeFakeEndpoint($response = [], $status = 200)
+{
+    $reflection = new \ReflectionObject(Http::getFacadeRoot());
+    $property = $reflection->getProperty('stubCallbacks');
+    $property->setAccessible(true);
+    $property->setValue(Http::getFacadeRoot(), collect());
+
+    Http::fake([
+        '*' => Http::response($response, $status),
+    ]);
+
+    PanicControl::clear();
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,7 +30,7 @@ class TestCase extends Orchestra
     {
         config()->set('database.default', 'testing');
         config()->set('panic-control.stores.database.connection', 'testing');
-        config()->set('panic-control.cache.time', 0);
+        config()->set('panic-control.cache.ttl', 0);
 
         $migration = include __DIR__.'/../database/migrations/create_panic_control_table.php.stub';
         $migration->up();
@@ -40,7 +40,7 @@ class TestCase extends Orchestra
     {
         match (config('panic-control.default')) {
             'database' => $this->assertDatabaseHas(config('panic-control.stores.database.table'), $parameters),
-            'file' => count(Arr::where(PanicControl::all(), function (array $value, int|string $key) use ($parameters) {
+            'endpoint', 'file' => count(Arr::where(PanicControl::all(), function (array $value, int|string $key) use ($parameters) {
                 $return = true;
                 foreach ($parameters as $k => $v) {
                     if ($value[$k] != $v) {
@@ -58,7 +58,7 @@ class TestCase extends Orchestra
     {
         match (config('panic-control.default')) {
             'database' => $this->assertDatabaseMissing(config('panic-control.stores.database.table'), $parameters),
-            'file' => count(Arr::where(PanicControl::all(), function (array $value, int|string $key) use ($parameters) {
+            'endpoint', 'file' => count(Arr::where(PanicControl::all(), function (array $value, int|string $key) use ($parameters) {
                 $return = true;
                 foreach ($parameters as $k => $v) {
                     if ($value[$k] != $v) {


### PR DESCRIPTION
- [x] fixed #5 
- [x] fix: add empty rules on factory
- [x] fix: import PanicControl\Stores\FileStore on resources/stubs/PanicControlServiceProvider.php.stub
- [x] fix: remove Final Keyword[ ¶](https://www.php.net/manual/en/language.oop5.final.php#language.oop5.final) for Store Classes
- [x] feat: test helper createPanic($count, $parameters) for create panics depending on the store
- [x] feat: test helper makeFakeEndpoint($response, $status) for create fake endpoint with parameters
- [x] refact: change config('panic-control.cache.time') to config('panic-control.cache.ttl')